### PR TITLE
Send PONG with prefixes

### DIFF
--- a/lib/irc/handler.ex
+++ b/lib/irc/handler.ex
@@ -758,10 +758,10 @@ defmodule M51.IrcConn.Handler do
         send_numeric.("410", ["CAP", "Missing CAP subcommand"])
 
       {"PING", [cookie]} ->
-        send.(%M51.Irc.Command{command: "PONG", params: [cookie]})
+        send.(%M51.Irc.Command{source: "server.", command: "PONG", params: [cookie]})
 
       {"PING", [_, cookie | _]} ->
-        send.(%M51.Irc.Command{command: "PONG", params: [cookie]})
+        send.(%M51.Irc.Command{source: "server.", command: "PONG", params: [cookie]})
 
       {"PING", []} ->
         send_needmoreparams.()

--- a/test/irc/handler_test.exs
+++ b/test/irc/handler_test.exs
@@ -314,7 +314,7 @@ defmodule M51.IrcConn.HandlerTest do
     assert_welcome("foo:bar")
 
     send(handler, cmd("PING sync2"))
-    assert_line("PONG :sync2\r\n")
+    assert_line(":server. PONG :sync2\r\n")
 
     assert M51.IrcConn.State.nick(state) == "foo:bar"
     assert M51.IrcConn.State.gecos(state) == "My GECOS"
@@ -419,7 +419,7 @@ defmodule M51.IrcConn.HandlerTest do
     do_connection_registration(handler)
 
     send(handler, cmd("@label=abcd PING sync1"))
-    assert_line("@label=abcd PONG :sync1\r\n")
+    assert_line("@label=abcd :server. PONG :sync1\r\n")
   end
 
   test "joining a room", %{handler: handler} do
@@ -435,7 +435,7 @@ defmodule M51.IrcConn.HandlerTest do
     send(handler, cmd("TAGMSG #"))
 
     send(handler, cmd("PING sync1"))
-    assert_line("PONG :sync1\r\n")
+    assert_line(":server. PONG :sync1\r\n")
   end
 
   test "sending privmsg", %{handler: handler} do
@@ -690,7 +690,7 @@ defmodule M51.IrcConn.HandlerTest do
 
     # No reply because the room is not synced (and never will be)
     send(handler, cmd("PING sync1"))
-    assert_line("PONG :sync1\r\n")
+    assert_line(":server. PONG :sync1\r\n")
 
     send(handler, cmd("@label=l2 WHO #existing_room:example.org"))
 
@@ -719,7 +719,7 @@ defmodule M51.IrcConn.HandlerTest do
 
     # No reply because the room is not synced (and never will be)
     send(handler, cmd("PING sync1"))
-    assert_line("PONG :sync1\r\n")
+    assert_line(":server. PONG :sync1\r\n")
 
     send(handler, cmd("WHO #existing_room:example.org"))
 


### PR DESCRIPTION
Closes GH-33.

This works around an issue where HexChat doesn't parse the PONG as expected and times out the connection:
https://github.com/hexchat/hexchat/issues/2738