### PR TITLE
irc2matrix: map colour 12 to a lighter blue

### DIFF
--- a/lib/format/irc2matrix.ex
+++ b/lib/format/irc2matrix.ex
@@ -58,7 +58,7 @@ defmodule M51.Format.Irc2Matrix do
     # 11, light cyan
     "#00FFFF",
     # 12, light blue
-    "#0000FC",
+    "#0080FF",
     # 13, pink
     "#FF00FF",
     # 14, grey


### PR DESCRIPTION
The current "light blue" is pretty hard to read on Element's dark theme. I've changed it to use #0080FF instead

Before:
![colors-before](https://user-images.githubusercontent.com/4644601/208007296-e72bd4d2-dd96-4e94-8f20-41537eb098c2.png)

After:

![colors-after](https://user-images.githubusercontent.com/4644601/208007310-34dfe2a6-654b-46ad-a165-11b2fb7a6797.png)
