### PR TITLE
Remove unnecessary json-decode on http errors in raw-client/poller

### DIFF
--- a/lib/matrix/raw_client.ex
+++ b/lib/matrix/raw_client.ex
@@ -37,12 +37,8 @@ defmodule M51.Matrix.RawClient do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, Jason.decode!(body)}
 
-      {:ok, %HTTPoison.Response{status_code: status_code, body: <<?<, _::binary>> = body}} ->
-        # That's not JSON!
-        {:error, status_code, body}
-
       {:ok, %HTTPoison.Response{status_code: status_code, body: body}} ->
-        {:error, status_code, Jason.decode!(body)}
+        {:error, status_code, body}
 
       {:error, %HTTPoison.Error{reason: reason}} ->
         {:error, nil, reason}


### PR DESCRIPTION
M51.Matrix.RawClient.get tries to decode non-200 responses as JSON and fails with errors like reported in https://github.com/progval/matrix2051/issues/24
As far as I can tell, result of this decoding is never used anywhere, so might as well return unchanged body, and if it'll ever be useful to log somewhere, can probably be done without decoding just fine too.

Intended to address https://github.com/progval/matrix2051/issues/24 , which I've also bumped into, to at least have matrix2051 poller crash with proper error and not on pointless json decoding.