### PR TITLE
Handle (log/fallback) connection errors when fetching well-known/matrix/client URLs

### DIFF
--- a/test/format/common_test.exs
+++ b/test/format/common_test.exs
@@ -117,21 +117,21 @@ defmodule M51.FormatTest do
 
   test "Matrix link to IRC" do
     MockHTTPoison
-    |> expect(:get!, 4, fn url ->
+    |> expect(:get, 4, fn url ->
       assert url == "https://example.org/.well-known/matrix/client"
 
-      %HTTPoison.Response{
+      {:ok, %HTTPoison.Response{
         status_code: 200,
         body: ~s({"m.homeserver": {"base_url": "https://api.example.org"}})
-      }
+      }}
     end)
-    |> expect(:get!, 1, fn url ->
+    |> expect(:get, 1, fn url ->
       assert url == "https://homeserver.org/.well-known/matrix/client"
 
-      %HTTPoison.Response{
+      {:ok, %HTTPoison.Response{
         status_code: 200,
         body: ~s({"m.homeserver": {"base_url": "https://api.homeserver.org"}})
-      }
+      }}
     end)
 
     assert M51.Format.matrix2irc(~s(<a href="https://example.org">foo</a>)) ==
@@ -178,13 +178,13 @@ defmodule M51.FormatTest do
 
   test "Matrix link to IRC (404 on well-known)" do
     MockHTTPoison
-    |> expect(:get!, 1, fn url ->
+    |> expect(:get, 1, fn url ->
       assert url == "https://example.org/.well-known/matrix/client"
 
-      %HTTPoison.Response{
+      {:ok, %HTTPoison.Response{
         status_code: 404,
         body: ~s(this is not JSON)
-      }
+      }}
     end)
 
     assert M51.Format.matrix2irc(~s(<img src="mxc://example.org/foo" />)) ==

--- a/test/matrix_client/client_test.exs
+++ b/test/matrix_client/client_test.exs
@@ -32,9 +32,9 @@ defmodule M51.MatrixClient.ClientTest do
 
   def expect_login(mock_httpoison) do
     mock_httpoison
-    |> expect(:get!, fn url ->
+    |> expect(:get, fn url ->
       assert url == "https://matrix.example.org/.well-known/matrix/client"
-      %HTTPoison.Response{status_code: 404, body: "Error 404"}
+      {:ok, %HTTPoison.Response{status_code: 404, body: "Error 404"}}
     end)
     |> expect(:get!, fn url ->
       assert url == "https://matrix.example.org/_matrix/client/r0/login"
@@ -81,15 +81,15 @@ defmodule M51.MatrixClient.ClientTest do
 
   test "connection to non-homeserver", %{sup_pid: sup_pid} do
     MockHTTPoison
-    |> expect(:get!, fn url ->
+    |> expect(:get, fn url ->
       assert url == "https://example.org/.well-known/matrix/client"
 
-      %HTTPoison.Response{
+      {:ok, %HTTPoison.Response{
         status_code: 404,
         body: """
           Error 404
         """
-      }
+      }}
     end)
     |> expect(:get!, fn url ->
       assert url == "https://example.org/_matrix/client/r0/login"
@@ -119,15 +119,15 @@ defmodule M51.MatrixClient.ClientTest do
 
   test "connection without well-known", %{sup_pid: sup_pid} do
     MockHTTPoison
-    |> expect(:get!, fn url ->
+    |> expect(:get, fn url ->
       assert url == "https://matrix.example.org/.well-known/matrix/client"
 
-      %HTTPoison.Response{
+      {:ok, %HTTPoison.Response{
         status_code: 404,
         body: """
           Error 404
         """
-      }
+      }}
     end)
     |> expect(:get!, fn url ->
       assert url == "https://matrix.example.org/_matrix/client/r0/login"
@@ -192,8 +192,8 @@ defmodule M51.MatrixClient.ClientTest do
 
   test "connection with well-known", %{sup_pid: sup_pid} do
     MockHTTPoison
-    |> expect(:get!, fn _url ->
-      %HTTPoison.Response{
+    |> expect(:get, fn _url ->
+      {:ok, %HTTPoison.Response{
         status_code: 200,
         body: """
           {
@@ -202,7 +202,7 @@ defmodule M51.MatrixClient.ClientTest do
             }
           }
         """
-      }
+      }}
     end)
     |> expect(:get!, fn url ->
       assert url == "https://matrix.example.com/_matrix/client/r0/login"
@@ -270,15 +270,15 @@ defmodule M51.MatrixClient.ClientTest do
 
   test "connection without password flow", %{sup_pid: sup_pid} do
     MockHTTPoison
-    |> expect(:get!, fn url ->
+    |> expect(:get, fn url ->
       assert url == "https://matrix.example.org/.well-known/matrix/client"
 
-      %HTTPoison.Response{
+      {:ok, %HTTPoison.Response{
         status_code: 404,
         body: """
           Error 404
         """
-      }
+      }}
     end)
     |> expect(:get!, fn url ->
       assert url == "https://matrix.example.org/_matrix/client/r0/login"
@@ -314,15 +314,15 @@ defmodule M51.MatrixClient.ClientTest do
 
   test "connection with invalid password", %{sup_pid: sup_pid} do
     MockHTTPoison
-    |> expect(:get!, fn url ->
+    |> expect(:get, fn url ->
       assert url == "https://matrix.example.org/.well-known/matrix/client"
 
-      %HTTPoison.Response{
+      {:ok, %HTTPoison.Response{
         status_code: 404,
         body: """
           Error 404
         """
-      }
+      }}
     end)
     |> expect(:get!, fn url ->
       assert url == "https://matrix.example.org/_matrix/client/r0/login"
@@ -374,9 +374,9 @@ defmodule M51.MatrixClient.ClientTest do
 
   test "registration", %{sup_pid: sup_pid} do
     MockHTTPoison
-    |> expect(:get!, fn url ->
+    |> expect(:get, fn url ->
       assert url == "https://matrix.example.org/.well-known/matrix/client"
-      %HTTPoison.Response{status_code: 404, body: "Error 404"}
+      {:ok, %HTTPoison.Response{status_code: 404, body: "Error 404"}}
     end)
     |> expect(:post!, fn url, body ->
       assert url == "https://matrix.example.org/_matrix/client/r0/register"

--- a/test/matrix_client/poller_test.exs
+++ b/test/matrix_client/poller_test.exs
@@ -1146,23 +1146,23 @@ defmodule M51.MatrixClient.PollerTest do
     test "messages (is_backlog=#{is_backlog})" do
       if unquote(is_backlog) do
         MockHTTPoison
-        |> expect(:get!, 0, fn url ->
+        |> expect(:get, 0, fn url ->
           assert url == "https://matrix.org/.well-known/matrix/client"
 
-          %HTTPoison.Response{
+          {:ok, %HTTPoison.Response{
             status_code: 200,
             body: ~s({"m.homeserver": {"base_url": "https://matrix-client.matrix.org"}})
-          }
+          }}
         end)
       else
         MockHTTPoison
-        |> expect(:get!, 5, fn url ->
+        |> expect(:get, 5, fn url ->
           assert url == "https://matrix.org/.well-known/matrix/client"
 
-          %HTTPoison.Response{
+          {:ok, %HTTPoison.Response{
             status_code: 200,
             body: ~s({"m.homeserver": {"base_url": "https://matrix-client.matrix.org"}})
-          }
+          }}
         end)
       end
 


### PR DESCRIPTION
When running `case httpoison.get!(wellknown_url) do` for ".../.well-known/matrix/client" links, connection errors can be common for variety of reasons, and afaict there's no need to treat them any differently than e.g. http-500 temporary errors - i.e. fallback to base_url with a warning.

These errors look like this:
```
00:55:48.583 [error] GenServer {M51.Registry, {#PID<0.4730.0>, :matrix_client}} terminating
** (HTTPoison.Error) :econnrefused
    (httpoison 1.8.2) lib/httpoison.ex:258: HTTPoison.request!/5
    (matrix2051 0.1.0) lib/matrix_client/client.ex:452: M51.MatrixClient.Client.get_base_url/2
    (matrix2051 0.1.0) lib/matrix_client/client.ex:76: M51.MatrixClient.Client.handle_call/3
    (stdlib 4.1.1) gen_server.erl:1149: :gen_server.try_handle_call/4
    (stdlib 4.1.1) gen_server.erl:1178: :gen_server.handle_msg/6
    (stdlib 4.1.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

Fix is to use non-trailing-bang get(), handling :error case from there with its own warning message.
