### PR TITLE
poller.poll_one: handle and retry on clean connection-closed events

### DIFF
--- a/lib/matrix_client/poller.ex
+++ b/lib/matrix_client/poller.ex
@@ -83,6 +83,10 @@ defmodule M51.MatrixClient.Poller do
       {:error, code, _} when code >= 500 and code < 600 ->
         # server error, try again
         poll_one(sup_pid, since, raw_client)
+
+      {:error, nil, :closed} ->
+        # server closed connection, likely due to timeout, retry
+        poll_one(sup_pid, since, raw_client)
     end
   end
 


### PR DESCRIPTION
When running matrix2051, sometimes I get these crashes:

```
16:12:43.784 [error] Task #PID<0.4784.0> started from #PID<0.4778.0> terminating
** (CaseClauseError) no case clause matching: {:error, nil, :closed}
    (matrix2051 0.1.0) lib/matrix_client/poller.ex:78: M51.MatrixClient.Poller.poll_one/3
    (matrix2051 0.1.0) lib/matrix_client/poller.ex:58: M51.MatrixClient.Poller.loop_poll/2
    (elixir 1.14.0) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (stdlib 4.1.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: &M51.MatrixClient.Poller.poll/1
    Args: [{#PID<0.4778.0>}]
```

Which look like clean connection closing from server, either on an overly-long poll and timeout, or due to any kind of server restart/maintenance on the other end.
It'd seem to make sense to handle these cleanly and simply retry, same as with http-500 errors.