### PR TITLE
sender: replace leftover IO.inspect calls with Logging

### DIFF
--- a/lib/matrix_client/sender.ex
+++ b/lib/matrix_client/sender.ex
@@ -22,6 +22,8 @@ defmodule M51.MatrixClient.Sender do
   """
   use Task, restart: :permanent
 
+  require Logger
+
   # totals 4 minutes, as the backoff of each attempt is 2^(number of attempts so far)
   @max_attempts 7
 
@@ -62,7 +64,7 @@ defmodule M51.MatrixClient.Sender do
 
         body = Jason.encode!(event)
 
-        IO.inspect(body, label: "sending")
+        Logger.debug("Sending event: #{body}")
 
         case M51.Matrix.RawClient.put(raw_client, path, body) do
           {:ok, _body} ->
@@ -70,7 +72,7 @@ defmodule M51.MatrixClient.Sender do
 
           {:error, _status_code, reason} ->
             if nb_attempts < @max_attempts do
-              IO.inspect(reason, label: "error while sending event, retrying")
+              Logger.warn("Error while sending event, retrying: #{reason}")
               backoff_delay = :math.pow(2, nb_attempts)
               Process.sleep(round(backoff_delay * 1000))
 
@@ -83,7 +85,7 @@ defmodule M51.MatrixClient.Sender do
                 nb_attempts + 1
               )
             else
-              IO.inspect(reason, label: "error while sending event, giving up")
+              Logger.warn("Error while sending event, giving up: #{reason}")
               state = M51.IrcConn.Supervisor.matrix_state(sup_pid)
               channel = M51.MatrixClient.State.room_irc_channel(state, room_id)
 


### PR DESCRIPTION
I assume these IO.inspect calls might be leftover from before the switch to using Logging.
"sending" call in particular I had to remove with a local patch to avoid spamming logs with what seem to be a debug info, but others should not happen normally, so replaced them with warnings.
There seem to be no IO.inspect calls in any other code here.
