### PR TITLE
poller.poll_one: fix delay type in Process.sleep()

### DIFF
--- a/lib/matrix_client/poller.ex
+++ b/lib/matrix_client/poller.ex
@@ -26,9 +26,9 @@ defmodule M51.MatrixClient.Poller do
   #  - Initial (re-)connection is always made immediately.
   #  - After that, min delay is added, multiplied by factor on every fail, up to max.
   #  - When connection succeeds, delay is reset.
-  # min/max delays are set in seconds here.
-  @connect_delay_min 1
-  @connect_delay_max 60
+  # min/max delays are set in milliseconds here.
+  @connect_delay_min 1_000
+  @connect_delay_max 60_000
   @connect_delay_factor 1.6
 
   def start_link(args) do
@@ -89,10 +89,10 @@ defmodule M51.MatrixClient.Poller do
     delay =
       if delay do
         Logger.warn(
-          "Server connection error [#{reconnect_reason}], retrying after #{delay}s"
+          "Server connection error [#{reconnect_reason}], retrying after #{round(delay/1000)}s"
         )
-        Process.sleep(delay * 1000)
-        Kernel.min(delay * @connect_delay_factor, @connect_delay_max)
+        Process.sleep(delay)
+        round(min(delay * @connect_delay_factor, @connect_delay_max))
       else
         @connect_delay_min
       end


### PR DESCRIPTION
Sorry, my bad for over-optimistically not testing this code at all in the first place, as it had a lot of issues pointed out in the initial PR, and this one still left afterwards.
Did run it through simple firewall blocking and `ss --kill` now, works as expected.

Thought erlang/elixir do convert values with their dynamic types, but that doesn't seem to kick-in when picking function signatures. Fix keeps the type a consistent integer via rounding after increments.
Also dropped "Kernel." prefix there for brevity, as docs say that it's always imported implicitly.

Issue looks like this in the process output:
```
10:20:38.380 [warning] Server connection error [http-server-error], retrying after 10s
10:20:50.058 [warning] Server connection error [http-server-error], retrying after 16.0s
10:20:50.058 [error] Task #PID<0.1123.0> started from #PID<0.1117.0> terminating
** (FunctionClauseError) no function clause matching in Process.sleep/1
    (elixir 1.14.0) lib/process.ex:250: Process.sleep(16000.0)
    (matrix2051 0.1.0) lib/matrix_client/poller.ex:94: M51.MatrixClient.Poller.poll_one/5
    (matrix2051 0.1.0) lib/matrix_client/poller.ex:69: M51.MatrixClient.Poller.loop_poll/2
    (elixir 1.14.0) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (stdlib 4.1.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: &M51.MatrixClient.Poller.poll/1
    Args: [{#PID<0.1117.0>}]
```

EDIT:
Also of minor note - this time it's persistent "http-server-error" and not a connection issue.
Given roughly same software running on all matrix instances, wonder why no one else seem to have been bothered by such issues - am I running the thing differently, or maybe most people don't pay attention to restarts/reconnects at all, or it's just foss.wtf server that runs way worse than most?
