### PR TITLE
Fix control characters for underline and stroke being reversed

### DIFF
--- a/lib/format/irc2matrix.ex
+++ b/lib/format/irc2matrix.ex
@@ -346,10 +346,10 @@ defmodule M51.Format.Irc2Matrix do
           :italic
 
         "\x1e" ->
-          :underlined
+          :stroke
 
         "\x1f" ->
-          :stroke
+          :underlined
 
         <<0x03, a, b, ?,, c, d>> ->
           {:color, color2hex((a - ?0) * 10 + (b - ?0)), color2hex((c - ?0) * 10 + (d - ?0))}


### PR DESCRIPTION
They're correct elsewhere (e.g. `lib/format/common.ex` but swapped in this file.