### PR TITLE
Add docker instructions + fix instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,14 +66,37 @@ Alternatively a Containerfile is provided as well for convenience. The
 image can be built with either [podman](https://podman.io/) or
 [docker](https://www.docker.com/).
 
+First you will need to clone the repo and cd into it. 
+You will need to copy the Containerfile to the root of the project folder too:
+
+```
+git clone https://github.com/progval/matrix2051.git
+cd matrix2051
+cp dist/Containerfile Dockerfile
+```
+
+## Podman
 To build it:
 
 ```
-podman build -t matrix2051 --file dist/Containerfile .
+podman build -t matrix2051 --file Containerfile .
 ```
 
 To run it:
 
 ```
 podman run --publish 2051:2051 --interactive matrix2051
+```
+
+## Docker
+To build it:
+
+```
+docker build -t matrix2051 .
+```
+
+To run it:
+
+```
+docker run -p 2051:2051 -it matrix2051
 ```

--- a/dist/Containerfile
+++ b/dist/Containerfile
@@ -6,7 +6,7 @@ RUN apk add --update --no-cache elixir
 
 WORKDIR /app
 
-COPY ../ /app
+COPY . /app
 
 RUN mix deps.get
 RUN mix release


### PR DESCRIPTION
This pr includes the docker instructions from #72 but also includes some corrections to the existing instructions. It now details cloning the source code and moving into it but most importantly a critical step where the Containerfile needs to be copied to the root of the project folder to correctly build.

It also reverts the "fix" made in commit https://github.com/progval/matrix2051/commit/0a3989a2e4126227aef38e10baa490b9064e83aa since it doesn't change anything but does add minor complexity.