### PR TITLE
Build and publish container to GHCR

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,6 +21,5 @@ jobs:
               uses: docker/build-push-action@v7
               with:
                   push: true
-                  context: .
-                  file: dist/Containerfile
+                  file: ./dist/Containerfile
                   tags: ghcr.io/progval/matrix2051:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,26 @@
+name: Publish to GHCR
+on:
+    push:
+        branches: ["main"]
+
+jobs:
+    build-and-push-image:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Log in to the Container registry
+              uses: docker/login-action@v4
+              with:
+                  registry: https://ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v7
+              with:
+                  push: true
+                  context: .
+                  file: dist/Containerfile
+                  tags: ghcr.io/progval/matrix2051:latest


### PR DESCRIPTION
This PR adds github workflow which builds docker/podman container and pushes it to GHCR  (Github Container Registry)